### PR TITLE
Mark Matrix links as coming soon

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const currentYear = new Date().getFullYear();
 // Social links can be kept or updated based on priorities
 const socialLinks = [
   { href: "https://github.com/InterCooperative-Network", label: "GitHub", iconName: "github" }, 
-  { href: "https://matrix.to/#/#icn:matrix.org", label: "Matrix", iconName: "matrix" },
+  { href: "#", label: "Matrix (coming soon)", iconName: "matrix" },
   { href: "mailto:contact@intercooperative.network", label: "Email", iconName: "email" }
 ];
 
@@ -85,7 +85,7 @@ const footerNavLinks = [
     
     <div class="mb-6 text-sm text-slate-gray text-center">
       <span>Spot an issue or have a suggestion? </span>
-      <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:underline">Join our Matrix</a>
+      <span class="text-blue-400">Matrix server coming soon</span>
       <span> or </span>
       <a href="https://github.com/orgs/InterCooperative-Network/discussions" target="_blank" rel="noopener noreferrer" class="text-blue-400 hover:underline">open a Discussion</a>
       <span>!</span>

--- a/src/components/MatrixInvite.astro
+++ b/src/components/MatrixInvite.astro
@@ -1,18 +1,18 @@
 ---
 // Placeholder for MatrixInvite component
-const matrixRoomLink = "https://matrix.to/#/#icn:matrix.org"; // Replace with actual Matrix room link
+// Matrix server not yet live, link disabled until launch
+const matrixRoomLink = "#";
 ---
 
 <div class="matrix-invite-card my-8 p-6 bg-gray-800 rounded-lg shadow-lg">
-  <h2 class="text-2xl font-bold mb-4 text-teal-400">Join our Matrix Community!</h2>
+  <h2 class="text-2xl font-bold mb-4 text-teal-400">Matrix Server Coming Soon</h2>
   <p class="text-gray-300 mb-4">
-    Connect with other members, ask questions, and participate in discussions on our Matrix server.
+    We're setting up our Matrix space. Check back soon to chat with the community.
   </p>
   <a href={matrixRoomLink}
-     target="_blank"
-     rel="noopener noreferrer"
-     class="btn btn-primary"
+     class="btn btn-primary cursor-not-allowed opacity-50"
+     aria-disabled="true"
   >
     Join Matrix Chat
   </a>
-</div> 
+</div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -61,9 +61,7 @@ import Layout from '../layouts/Layout.astro';
             ICN is an evolving ecosystem. We invite you to explore our documentation, join the conversation in our community channels, and help shape the future of a truly cooperative internet.
           </p>
           <div class="flex flex-col sm:flex-row justify-center items-center gap-4">
-            <a href="https://matrix.to/#/#icn-general:matrix.org" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">
-              Chat on Matrix
-            </a>
+            <span class="btn btn-secondary cursor-not-allowed opacity-50">Matrix server coming soon</span>
             <a href="/docs" class="btn btn-primary">
               Read the Docs
             </a>

--- a/src/pages/blog/sample-post.astro
+++ b/src/pages/blog/sample-post.astro
@@ -51,7 +51,7 @@ const post = {
 
         <h2 class="text-2xl font-semibold mt-8 mb-4">Join the Conversation</h2>
         <p>
-          This blog is not just a one-way street. We encourage you to engage with the posts, share your thoughts in our community channels (especially our <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer">Matrix space</a>), and let us know what topics you'd like to see covered.
+          This blog is not just a one-way street. We encourage you to engage with the posts, share your thoughts in our community channels (our Matrix server is coming soon), and let us know what topics you'd like to see covered.
         </p>
         <p>
           The InterCooperative Network is built by and for its community. Your participation, feedback, and contributions are vital to our success. 

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -64,9 +64,7 @@ import MatrixInvite from '../components/MatrixInvite.astro'; // Assuming this co
   <aside class="bg-blue-50 p-8 my-12 text-center">
     <h2 class="text-3xl font-bold mb-4">Get Involved!</h2>
     <p class="mb-6 max-w-2xl mx-auto">Whether you're a developer, designer, writer, or just passionate about a cooperative internet, there's a place for you in ICN. Join our Matrix, explore projects, or start a discussion.</p>
-    <a href="https://matrix.to/#/#icn:matrix.org" target="_blank" rel="noopener noreferrer" class="btn btn-primary">
-      Join Matrix Discussion
-    </a>
+    <span class="btn btn-primary cursor-not-allowed opacity-50">Matrix server coming soon</span>
     {/* This link should ideally point to the MatrixInvite component or a direct Matrix link */}
   </aside>
 

--- a/src/pages/governance.astro
+++ b/src/pages/governance.astro
@@ -14,7 +14,7 @@ import GitHubRepoCard from '../components/GitHubRepoCard.astro';
 
   <ul class="list-disc ml-6 text-white mt-6 space-y-2">
     <li><a href="https://gov.intercooperative.network" target="_blank">AgoraNet: Deliberation & Proposals</a></li>
-    <li><a href="https://chat.intercooperative.network" target="_blank">Matrix: Real-Time Governance Channels</a></li>
+    <li>Matrix: Real-Time Governance Channels (coming soon)</li>
     <li><a href="https://github.com/InterCooperative-Network/icn-governance" target="_blank">GitHub: Governance Source</a></li>
   </ul>
 

--- a/src/pages/infrastructure.astro
+++ b/src/pages/infrastructure.astro
@@ -17,7 +17,7 @@ import GitHubRepoCard from '../components/GitHubRepoCard.astro';
     <li><strong>Docs:</strong> <a href="https://docs.intercooperative.network">docs.intercooperative.network</a></li>
     <li><strong>Wallet:</strong> <a href="https://wallet.intercooperative.network">wallet.intercooperative.network</a></li>
     <li><strong>AgoraNet:</strong> <a href="https://gov.intercooperative.network">gov.intercooperative.network</a></li>
-    <li><strong>Matrix:</strong> <a href="https://chat.intercooperative.network">chat.intercooperative.network</a></li>
+    <li><strong>Matrix:</strong> chat.intercooperative.network (coming soon)</li>
   </ul>
 
   <MatrixInvite />


### PR DESCRIPTION
## Summary
- disable Matrix link in MatrixInvite component and note that it's not live yet
- mark Matrix social link in the footer as coming soon
- update pages to remove direct Matrix links and display 'Matrix server coming soon'

## Testing
- `npm run lint` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2cc68f20832484eeb4f2bb481033